### PR TITLE
feat: open single marker as ROI (region of interest) in 3d viewer [RQ-0202]

### DIFF
--- a/released_plugins/v3d_plugins/MIND/soma_segmentation_plugin.cpp
+++ b/released_plugins/v3d_plugins/MIND/soma_segmentation_plugin.cpp
@@ -200,28 +200,63 @@ void reconstruction_func(V3DPluginCallback2 &callback, QWidget *parent,
     c = PARA.channel;
   }
 
-  // main neuron reconstruction code
-
   //// THIS IS WHERE THE DEVELOPERS SHOULD ADD THEIR OWN NEURON TRACING CODE
 
-  // Output
-  NeuronTree nt;
-  QString swc_name = PARA.inimg_file + "_soma_segmentation.swc";
-  nt.name = "soma_segmentation";
-  writeSWC_file(swc_name.toStdString().c_str(), nt);
+  // get current window, image, and landmarks
+  v3dhandle curwin = callback.currentImageWindow();
+  Image4DSimple *p4DImage = callback.getImage(curwin);
+  LandmarkList landmarkList = callback.getLandmark(curwin);
 
-  if (!bmenu) {
-    if (data1d) {
-      delete[] data1d;
-      data1d = 0;
-    }
+  // reset ROI
+  ROIList roiList = callback.getROI(curwin);
+  for (int j = 0; j < 3; j++) {
+    roiList[j].clear();
   }
 
-  v3d_msg(
-      QString(
-          "Now you can drag and drop the generated swc fle [%1] into Vaa3D.")
-          .arg(swc_name.toStdString().c_str()),
-      bmenu);
+  // get 1st landmark
+  LocationSimple lm = landmarkList[0];
+  float x, y, z;
+  float radius;
+  x = lm.x;
+  y = lm.y;
+  z = lm.z;
+  radius = lm.radius;
+
+  v3d_msg(QString("Landmark: x=%1, y=%2, z=%3, radius=%4")
+              .arg(x)
+              .arg(y)
+              .arg(z)
+              .arg(radius),
+          bmenu);
+
+  // set ROI
+  float x_min = x - radius * 2.0f;
+  float x_max = x + radius * 2.0f;
+  float y_min = y - radius * 2.0f;
+  float y_max = y + radius * 2.0f;
+  float z_min = z - radius * 2.0f;
+  float z_max = z + radius * 2.0f;
+  roiList[0] << QPoint(x_min, y_min);
+  roiList[0] << QPoint(x_max, y_min);
+  roiList[0] << QPoint(x_max, y_max);
+  roiList[0] << QPoint(x_min, y_max);
+  roiList[1] << QPoint(z_min, y_min);
+  roiList[1] << QPoint(z_max, y_min);
+  roiList[1] << QPoint(z_max, y_max);
+  roiList[1] << QPoint(z_min, y_max);
+  roiList[2] << QPoint(x_min, z_min);
+  roiList[2] << QPoint(x_max, z_min);
+  roiList[2] << QPoint(x_max, z_max);
+  roiList[2] << QPoint(x_min, z_max);
+
+  if (callback.setROI(curwin, roiList)) {
+    callback.updateImageWindow(curwin);
+  } else {
+    qDebug() << "error: failed to set ROI";
+    return;
+  }
+
+  callback.openROI3DWindow(curwin);
 
   return;
 }

--- a/released_plugins/v3d_plugins/MIND/soma_segmentation_plugin.cpp
+++ b/released_plugins/v3d_plugins/MIND/soma_segmentation_plugin.cpp
@@ -230,20 +230,26 @@ void reconstruction_func(V3DPluginCallback2 &callback, QWidget *parent,
           bmenu);
 
   // set ROI
+  // ROIList being a QList<QPolygon>, and QPolygon being a QVector<QPoint>,
+  // we represent the x, y, and z planes as polygons with 4 points each to 
+  // form a cube with the landmark at the center
   float x_min = x - radius * 2.0f;
   float x_max = x + radius * 2.0f;
   float y_min = y - radius * 2.0f;
   float y_max = y + radius * 2.0f;
   float z_min = z - radius * 2.0f;
   float z_max = z + radius * 2.0f;
+  // x-y plane
   roiList[0] << QPoint(x_min, y_min);
   roiList[0] << QPoint(x_max, y_min);
   roiList[0] << QPoint(x_max, y_max);
   roiList[0] << QPoint(x_min, y_max);
+  // z-y plane
   roiList[1] << QPoint(z_min, y_min);
   roiList[1] << QPoint(z_max, y_min);
   roiList[1] << QPoint(z_max, y_max);
   roiList[1] << QPoint(z_min, y_max);
+  // x-z plane
   roiList[2] << QPoint(x_min, z_min);
   roiList[2] << QPoint(x_max, z_min);
   roiList[2] << QPoint(x_max, z_max);


### PR DESCRIPTION
# feat: open single marker as ROI (region of interest) in 3d viewer [RQ-0201]

> **RQ-0201:** The MIND system shall allow a user to view the area around a soma label with the voxel dimensions corrected to be isotropic 

## What

When given an image and a list of markers representing somas (marker in the middle with a radius), the plugin `soma_segmentation` will open the first marker and its region of interest (center + radius * 2) in a new window 3d viewer.

As a current workaround for isotropic  correction, it is possible to set the z-thickness directly in the 3D viewer.

## Uncertainties and what needs to be further developed for RQ-0201

- How to open the next marker after finishing with this one
- A way to change the default z-thickness so it is fixed
- How does the z-thickness actually work?
- I did not investigate if this works perfectly with TeraFly, in theory though it should. It's been tested with the 3D tiff

## Screenshots

_3D tiff with its somas identified as markers_
![image](https://github.com/user-attachments/assets/a449ed6c-4113-4472-abbd-0179d9d106f8)

_plugin to run_
![image](https://github.com/user-attachments/assets/8cee13e9-67a1-4860-aff9-8863468b9e0a)

_plugin notifies of the landmark's coordinates and radius_
![image](https://github.com/user-attachments/assets/d9e22c30-4f3d-4d9f-8da4-9e0ff4cee7fa)

_3D view of region of interest is opened_
![image](https://github.com/user-attachments/assets/f42f9050-ddbb-4411-bbd5-6f09dcb97092)

_sync to view marker_
![image](https://github.com/user-attachments/assets/a0aac201-b1fe-4a60-a613-de24a548e54a)

_z dimension can be modified through Z-thick to correct isotropic_
![image](https://github.com/user-attachments/assets/94d22b2b-aae9-4f8c-94b7-8b69a86bf6f3)
