### PR TITLE
feat: isotropic correction from user input [RQ-0201]

### DIFF
--- a/released_plugins/v3d_plugins/MIND/ResolutionDialog.cpp
+++ b/released_plugins/v3d_plugins/MIND/ResolutionDialog.cpp
@@ -1,0 +1,58 @@
+#include "ResolutionDialog.h"
+
+ResolutionDialog::ResolutionDialog(float x, float y, float z, float radius,
+                                   QWidget *parent)
+    : QDialog(parent) {
+  QFormLayout *formLayout = new QFormLayout;
+
+  QLabel *landmarkLabel = new QLabel(
+      QString("Landmark: x=%1, y=%2, z=%3, radius=%4\n\n"
+              "Enter resolutions of the image pixel along the 3 axes:")
+          .arg(x)
+          .arg(y)
+          .arg(z)
+          .arg(radius),
+      this);
+  formLayout->addRow(landmarkLabel);
+
+  xSpinBox = new QDoubleSpinBox(this);
+  ySpinBox = new QDoubleSpinBox(this);
+  zSpinBox = new QDoubleSpinBox(this);
+
+  // Set default values
+  xSpinBox->setValue(1.0);
+  ySpinBox->setValue(1.0);
+  zSpinBox->setValue(1.0);
+
+  // Set range for spin boxes
+  xSpinBox->setRange(0.01, 100.0);
+  ySpinBox->setRange(0.01, 100.0);
+  zSpinBox->setRange(0.01, 100.0);
+
+  // Set step size
+  xSpinBox->setSingleStep(1.0);
+  ySpinBox->setSingleStep(1.0);
+  zSpinBox->setSingleStep(1.0);
+
+  formLayout->addRow("Resolution X:", xSpinBox);
+  formLayout->addRow("Resolution Y:", ySpinBox);
+  formLayout->addRow("Resolution Z:", zSpinBox);
+
+  QDialogButtonBox *buttonBox = new QDialogButtonBox(
+      QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+  connect(buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
+  connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+  QVBoxLayout *mainLayout = new QVBoxLayout;
+  mainLayout->addLayout(formLayout);
+  mainLayout->addWidget(buttonBox);
+
+  setLayout(mainLayout);
+  setWindowTitle("Enter Resolutions");
+}
+
+double ResolutionDialog::getXResolution() const { return xSpinBox->value(); }
+
+double ResolutionDialog::getYResolution() const { return ySpinBox->value(); }
+
+double ResolutionDialog::getZResolution() const { return zSpinBox->value(); }

--- a/released_plugins/v3d_plugins/MIND/ResolutionDialog.cpp
+++ b/released_plugins/v3d_plugins/MIND/ResolutionDialog.cpp
@@ -1,24 +1,13 @@
 #include "ResolutionDialog.h"
 
-ResolutionDialog::ResolutionDialog(double x, double y, double z, double radius,
-                                   QWidget *parent)
-    : QDialog(parent),
-      xResolution(x),
-      yResolution(y),
-      zResolution(z),
-      radius(radius),
-      parent(parent) {
+ResolutionDialog::ResolutionDialog(QWidget *parent)
+    : QDialog(parent), parent(parent) {
   QFormLayout *formLayout = new QFormLayout;
 
-  QLabel *landmarkLabel = new QLabel(
-      QString("Landmark: x=%1, y=%2, z=%3, radius=%4\n\n"
-              "Enter resolutions of the image pixel along the 3 axes:")
-          .arg(x)
-          .arg(y)
-          .arg(z)
-          .arg(radius),
+  QLabel *helpDescriptionLabel = new QLabel(
+      QString("Enter resolutions of the image voxel in µm along the 3 axes:"),
       this);
-  formLayout->addRow(landmarkLabel);
+  formLayout->addRow(helpDescriptionLabel);
 
   xSpinBox = new QDoubleSpinBox(this);
   ySpinBox = new QDoubleSpinBox(this);

--- a/released_plugins/v3d_plugins/MIND/ResolutionDialog.cpp
+++ b/released_plugins/v3d_plugins/MIND/ResolutionDialog.cpp
@@ -1,8 +1,13 @@
 #include "ResolutionDialog.h"
 
-ResolutionDialog::ResolutionDialog(float x, float y, float z, float radius,
+ResolutionDialog::ResolutionDialog(double x, double y, double z, double radius,
                                    QWidget *parent)
-    : QDialog(parent) {
+    : QDialog(parent),
+      xResolution(x),
+      yResolution(y),
+      zResolution(z),
+      radius(radius),
+      parent(parent) {
   QFormLayout *formLayout = new QFormLayout;
 
   QLabel *landmarkLabel = new QLabel(
@@ -56,3 +61,22 @@ double ResolutionDialog::getXResolution() const { return xSpinBox->value(); }
 double ResolutionDialog::getYResolution() const { return ySpinBox->value(); }
 
 double ResolutionDialog::getZResolution() const { return zSpinBox->value(); }
+
+void ResolutionDialog::setResolutionOfImage(Image4DSimple *p4DImage) {
+  // Landmark info and ask for desired resolution of a image pixel along the 3
+  // axes for isotropic correction
+  double rez[3];
+  if (exec() == QDialog::Accepted) {
+    rez[0] = getXResolution();
+    rez[1] = getYResolution();
+    rez[2] = getZResolution();
+  } else {
+    qDebug() << "error: failed to get resolution";
+    return;
+  }
+
+  // Set resolution of the image
+  p4DImage->setRezX(rez[0]);
+  p4DImage->setRezY(rez[1]);
+  p4DImage->setRezZ(rez[2]);
+}

--- a/released_plugins/v3d_plugins/MIND/ResolutionDialog.h
+++ b/released_plugins/v3d_plugins/MIND/ResolutionDialog.h
@@ -23,8 +23,7 @@ class ResolutionDialog : public QDialog {
   Q_OBJECT
 
  public:
-  ResolutionDialog(double x, double y, double z, double radius,
-                   QWidget *parent = nullptr);
+  ResolutionDialog(QWidget *parent = nullptr);
 
   double getXResolution() const;
   double getYResolution() const;
@@ -36,7 +35,6 @@ class ResolutionDialog : public QDialog {
   double xResolution;
   double yResolution;
   double zResolution;
-  double radius;
   QWidget *parent;
   QDoubleSpinBox *xSpinBox;
   QDoubleSpinBox *ySpinBox;

--- a/released_plugins/v3d_plugins/MIND/ResolutionDialog.h
+++ b/released_plugins/v3d_plugins/MIND/ResolutionDialog.h
@@ -1,0 +1,37 @@
+/* ResolutionDialog.h
+ * This dialog allows the user to enter resolutions for a landmark and its image
+ * to be used in the soma segmentation plugin to correct for isotropic and
+ * z-thickness
+ *
+ * 2024-11-30 : by ImagiNeuron: Shidan Javaheri, Siger Ma, Athmane Benarous and
+ * Thibaut Baguette
+ */
+
+#ifndef __RESOLUTIONDIALOG_H__
+#define __RESOLUTIONDIALOG_H__
+
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QDoubleSpinBox>
+#include <QFormLayout>
+#include <QLabel>
+#include <QVBoxLayout>
+
+class ResolutionDialog : public QDialog {
+  Q_OBJECT
+
+ public:
+  ResolutionDialog(float x, float y, float z, float radius,
+                   QWidget *parent = nullptr);
+
+  double getXResolution() const;
+  double getYResolution() const;
+  double getZResolution() const;
+
+ private:
+  QDoubleSpinBox *xSpinBox;
+  QDoubleSpinBox *ySpinBox;
+  QDoubleSpinBox *zSpinBox;
+};
+
+#endif  // __RESOLUTIONDIALOG_H__

--- a/released_plugins/v3d_plugins/MIND/ResolutionDialog.h
+++ b/released_plugins/v3d_plugins/MIND/ResolutionDialog.h
@@ -17,18 +17,27 @@
 #include <QLabel>
 #include <QVBoxLayout>
 
+#include "basic_4dimage.h"
+
 class ResolutionDialog : public QDialog {
   Q_OBJECT
 
  public:
-  ResolutionDialog(float x, float y, float z, float radius,
+  ResolutionDialog(double x, double y, double z, double radius,
                    QWidget *parent = nullptr);
 
   double getXResolution() const;
   double getYResolution() const;
   double getZResolution() const;
 
+  void setResolutionOfImage(Image4DSimple *p4DImage);
+
  private:
+  double xResolution;
+  double yResolution;
+  double zResolution;
+  double radius;
+  QWidget *parent;
   QDoubleSpinBox *xSpinBox;
   QDoubleSpinBox *ySpinBox;
   QDoubleSpinBox *zSpinBox;

--- a/released_plugins/v3d_plugins/MIND/soma_segmentation.pro
+++ b/released_plugins/v3d_plugins/MIND/soma_segmentation.pro
@@ -8,7 +8,9 @@ INCLUDEPATH	+= $$VAA3DPATH/v3d_main/basic_c_fun
 INCLUDEPATH	+= $$VAA3DPATH/v3d_main/common_lib/include
 
 HEADERS	+= soma_segmentation_plugin.h
+HEADERS += ResolutionDialog.h
 SOURCES	+= soma_segmentation_plugin.cpp
+SOURCES += ResolutionDialog.cpp
 SOURCES	+= $$VAA3DPATH/v3d_main/basic_c_fun/v3d_message.cpp
 SOURCES	+= $$VAA3DPATH/v3d_main/basic_c_fun/basic_surf_objs.cpp
 

--- a/released_plugins/v3d_plugins/MIND/soma_segmentation_plugin.cpp
+++ b/released_plugins/v3d_plugins/MIND/soma_segmentation_plugin.cpp
@@ -283,9 +283,9 @@ void reconstruction_func(V3DPluginCallback2 &callback, QWidget *parent,
   z = lm.z;
   radius = lm.radius;
 
-  // Landmark info and ask for desired resolution of a image pixel along the 3
+  // Ask for desired resolution of a image pixel along the 3
   // axes for isotropic correction and set resolution of the image
-  ResolutionDialog dialog(x, y, z, radius, parent);
+  ResolutionDialog dialog(parent);
   dialog.setResolutionOfImage(p4DImage);
 
   // Set the ROI

--- a/released_plugins/v3d_plugins/MIND/soma_segmentation_plugin.cpp
+++ b/released_plugins/v3d_plugins/MIND/soma_segmentation_plugin.cpp
@@ -27,6 +27,9 @@ struct input_PARA {
 void reconstruction_func(V3DPluginCallback2 &callback, QWidget *parent,
                          input_PARA &PARA, bool bmenu);
 
+void setRegionOfInterest(V3DPluginCallback2 &callback, v3dhandle &curwin,
+                         float x, float y, float z, float radius);
+
 /**
  * @brief Menu option under the MIND plugins
  */
@@ -124,6 +127,59 @@ bool SomaSegmentation::dofunc(const QString &func_name,
   return true;
 }
 
+void setRegionOfInterest(V3DPluginCallback2 &callback, v3dhandle &curwin,
+                         float x, float y, float z, float radius) {
+  // reset ROI
+  ROIList roiList = callback.getROI(curwin);
+  for (int j = 0; j < 3; j++) {
+    roiList[j].clear();
+  }
+
+  // set ROI
+  // ROIList being a QList<QPolygon>, and QPolygon being a QVector<QPoint>,
+  // we represent the x, y, and z planes as polygons with 4 points each to
+  // form a cube with the landmark at the center
+  float x_min = x - radius * 2.0f;
+  float x_max = x + radius * 2.0f;
+  float y_min = y - radius * 2.0f;
+  float y_max = y + radius * 2.0f;
+  float z_min = z - radius * 2.0f;
+  float z_max = z + radius * 2.0f;
+  // x-y plane
+  roiList[0] << QPoint(x_min, y_min);
+  roiList[0] << QPoint(x_max, y_min);
+  roiList[0] << QPoint(x_max, y_max);
+  roiList[0] << QPoint(x_min, y_max);
+  // z-y plane
+  roiList[1] << QPoint(z_min, y_min);
+  roiList[1] << QPoint(z_max, y_min);
+  roiList[1] << QPoint(z_max, y_max);
+  roiList[1] << QPoint(z_min, y_max);
+  // x-z plane
+  roiList[2] << QPoint(x_min, z_min);
+  roiList[2] << QPoint(x_max, z_min);
+  roiList[2] << QPoint(x_max, z_max);
+  roiList[2] << QPoint(x_min, z_max);
+
+  if (callback.setROI(curwin, roiList)) {
+    callback.updateImageWindow(curwin);
+  } else {
+    qDebug() << "error: failed to set ROI";
+    return;
+  }
+
+  callback.openROI3DWindow(curwin);
+
+  // Update landmark
+  View3DControl *v3dlocalcontrol = callback.getLocalView3DControl(curwin);
+  if (v3dlocalcontrol) {
+    v3dlocalcontrol->updateLandmark();
+  } else {
+    qDebug() << "error: failed to update 3D viewer";
+    return;
+  }
+}
+
 /**
  * @brief Function to reconstruct somas
  *
@@ -214,12 +270,6 @@ void reconstruction_func(V3DPluginCallback2 &callback, QWidget *parent,
     return;
   }
 
-  // reset ROI
-  ROIList roiList = callback.getROI(curwin);
-  for (int j = 0; j < 3; j++) {
-    roiList[j].clear();
-  }
-
   // get 1st landmark
   if (landmarkList.size() < 1) {
     qDebug() << "error: no landmark found";
@@ -238,49 +288,8 @@ void reconstruction_func(V3DPluginCallback2 &callback, QWidget *parent,
   ResolutionDialog dialog(x, y, z, radius, parent);
   dialog.setResolutionOfImage(p4DImage);
 
-  // set ROI
-  // ROIList being a QList<QPolygon>, and QPolygon being a QVector<QPoint>,
-  // we represent the x, y, and z planes as polygons with 4 points each to
-  // form a cube with the landmark at the center
-  float x_min = x - radius * 2.0f;
-  float x_max = x + radius * 2.0f;
-  float y_min = y - radius * 2.0f;
-  float y_max = y + radius * 2.0f;
-  float z_min = z - radius * 2.0f;
-  float z_max = z + radius * 2.0f;
-  // x-y plane
-  roiList[0] << QPoint(x_min, y_min);
-  roiList[0] << QPoint(x_max, y_min);
-  roiList[0] << QPoint(x_max, y_max);
-  roiList[0] << QPoint(x_min, y_max);
-  // z-y plane
-  roiList[1] << QPoint(z_min, y_min);
-  roiList[1] << QPoint(z_max, y_min);
-  roiList[1] << QPoint(z_max, y_max);
-  roiList[1] << QPoint(z_min, y_max);
-  // x-z plane
-  roiList[2] << QPoint(x_min, z_min);
-  roiList[2] << QPoint(x_max, z_min);
-  roiList[2] << QPoint(x_max, z_max);
-  roiList[2] << QPoint(x_min, z_max);
-
-  if (callback.setROI(curwin, roiList)) {
-    callback.updateImageWindow(curwin);
-  } else {
-    qDebug() << "error: failed to set ROI";
-    return;
-  }
-
-  callback.openROI3DWindow(curwin);
-
-  // Update landmark
-  View3DControl *v3dlocalcontrol = callback.getLocalView3DControl(curwin);
-  if (v3dlocalcontrol) {
-    v3dlocalcontrol->updateLandmark();
-  } else {
-    qDebug() << "error: failed to update 3D viewer";
-    return;
-  }
+  // Set the ROI
+  setRegionOfInterest(callback, curwin, x, y, z, radius);
 
   return;
 }

--- a/released_plugins/v3d_plugins/MIND/soma_segmentation_plugin.cpp
+++ b/released_plugins/v3d_plugins/MIND/soma_segmentation_plugin.cpp
@@ -234,22 +234,9 @@ void reconstruction_func(V3DPluginCallback2 &callback, QWidget *parent,
   radius = lm.radius;
 
   // Landmark info and ask for desired resolution of a image pixel along the 3
-  // axes for isotropic correction
-  double rez[3];
+  // axes for isotropic correction and set resolution of the image
   ResolutionDialog dialog(x, y, z, radius, parent);
-  if (dialog.exec() == QDialog::Accepted) {
-    rez[0] = dialog.getXResolution();
-    rez[1] = dialog.getYResolution();
-    rez[2] = dialog.getZResolution();
-  } else {
-    qDebug() << "error: failed to get resolution";
-    return;
-  }
-
-  // Set resolution of the image
-  p4DImage->setRezX(rez[0]);
-  p4DImage->setRezY(rez[1]);
-  p4DImage->setRezZ(rez[2]);
+  dialog.setResolutionOfImage(p4DImage);
 
   // set ROI
   // ROIList being a QList<QPolygon>, and QPolygon being a QVector<QPoint>,

--- a/released_plugins/v3d_plugins/MIND/soma_segmentation_plugin.cpp
+++ b/released_plugins/v3d_plugins/MIND/soma_segmentation_plugin.cpp
@@ -34,14 +34,16 @@ void setRegionOfInterest(V3DPluginCallback2 &callback, v3dhandle &curwin,
  * @brief Menu option under the MIND plugins
  */
 QStringList SomaSegmentation::menulist() const {
-  return QStringList() << tr("soma_segmentation") << tr("about");
+  return QStringList() << tr("soma_segmentation") << tr("isotropic correction")
+                       << tr("about");
 }
 
 /**
  * @brief Function list for the soma segmentation plugin
  */
 QStringList SomaSegmentation::funclist() const {
-  return QStringList() << tr("segment_somas") << tr("help");
+  return QStringList() << tr("segment_somas") << tr("isotropic correction")
+                       << tr("help");
 }
 
 /**
@@ -58,6 +60,12 @@ void SomaSegmentation::domenu(const QString &menu_name,
     bool bmenu = true;
     input_PARA PARA;
     reconstruction_func(callback, parent, PARA, bmenu);
+
+  } else if (menu_name == tr("isotropic correction")) {
+    bool bmenu = true;
+    input_PARA PARA;
+
+    isotropic_correction_func(callback, parent, PARA, bmenu);
 
   } else {
     v3d_msg(tr(
@@ -290,6 +298,95 @@ void reconstruction_func(V3DPluginCallback2 &callback, QWidget *parent,
 
   // Set the ROI
   setRegionOfInterest(callback, curwin, x, y, z, radius);
+
+  return;
+}
+
+/**
+ * @brief Function to correct isotropic resolution of an image
+ *
+ * @param callback - the V3D plugin callback interface
+ * @param parent - the parent interface
+ * @param PARA - the input parameters
+ * @param bmenu - whether the function is being called from the menu
+ */
+void isotropic_correction_func(V3DPluginCallback2 &callback, QWidget *parent,
+                               input_PARA &PARA, bool bmenu) {
+  unsigned char *data1d = 0;
+  V3DLONG N, M, P, sc, c;
+  V3DLONG in_sz[4];
+  if (bmenu) {
+    v3dhandle curwin = callback.currentImageWindow();
+    if (!curwin) {
+      QMessageBox::information(
+          0, "", "You don't have any image open in the main window.");
+      return;
+    }
+
+    Image4DSimple *p4DImage = callback.getImage(curwin);
+
+    if (!p4DImage) {
+      QMessageBox::information(0, "",
+                               "The image pointer is invalid. Ensure your data "
+                               "is valid and try again!");
+      return;
+    }
+
+    data1d = p4DImage->getRawData();
+    N = p4DImage->getXDim();
+    M = p4DImage->getYDim();
+    P = p4DImage->getZDim();
+    sc = p4DImage->getCDim();
+
+    bool ok1;
+
+    if (sc == 1) {
+      c = 1;
+      ok1 = true;
+    } else {
+      c = QInputDialog::getInt(parent, "Channel", "Enter channel NO:", 1, 1, sc,
+                               1, &ok1);
+    }
+
+    if (!ok1) return;
+
+    in_sz[0] = N;
+    in_sz[1] = M;
+    in_sz[2] = P;
+    in_sz[3] = sc;
+
+    PARA.inimg_file = p4DImage->getFileName();
+  } else {
+    int datatype = 0;
+    if (!simple_loadimage_wrapper(callback,
+                                  PARA.inimg_file.toStdString().c_str(), data1d,
+                                  in_sz, datatype)) {
+      fprintf(stderr,
+              "Error happens in reading the subject file [%s]. Exit. \n",
+              PARA.inimg_file.toStdString().c_str());
+      return;
+    }
+    if (PARA.channel < 1 || PARA.channel > in_sz[3]) {
+      fprintf(stderr, "Invalid channel number. \n");
+      return;
+    }
+    N = in_sz[0];
+    M = in_sz[1];
+    P = in_sz[2];
+    sc = in_sz[3];
+    c = PARA.channel;
+  }
+
+  //// ISOTROPIC CORRECTION CODE GOES HERE
+
+  // get current window, imag
+  v3dhandle curwin = callback.currentImageWindow();
+  Image4DSimple *p4DImage = callback.getImage(curwin);
+
+  // Ask for desired resolution of a image pixel along the 3
+  // axes for isotropic correction and set resolution of the image
+  ResolutionDialog dialog(parent);
+  dialog.setResolutionOfImage(p4DImage);
 
   return;
 }

--- a/released_plugins/v3d_plugins/MIND/soma_segmentation_plugin.cpp
+++ b/released_plugins/v3d_plugins/MIND/soma_segmentation_plugin.cpp
@@ -30,6 +30,9 @@ void reconstruction_func(V3DPluginCallback2 &callback, QWidget *parent,
 void setRegionOfInterest(V3DPluginCallback2 &callback, v3dhandle &curwin,
                          float x, float y, float z, float radius);
 
+void isotropic_correction_func(V3DPluginCallback2 &callback, QWidget *parent,
+                               input_PARA &PARA, bool bmenu);
+
 /**
  * @brief Menu option under the MIND plugins
  */


### PR DESCRIPTION
# feat: isotropic correction from user input [RQ-0201]

> RQ-0201: The MIND system shall allow a user to view the area around a soma label with the voxel dimensions corrected to be isotropic 

# What?

- catch potential errors when no landmark has been defined
- ask z thickness from user to automatically update it in the 3D view
- automatically update landmark to show them in the 3D view

## Screenshot

![20241119-2330-59 9866841](https://github.com/user-attachments/assets/30625e81-21a5-4719-8611-c0a2dfd2b760)

![image](https://github.com/user-attachments/assets/e383a5c7-67ac-4b74-8f94-23ea068cab55)
![image](https://github.com/user-attachments/assets/99b6bd25-4b56-4931-bb52-69ae9f11268c)
![image](https://github.com/user-attachments/assets/637e3b61-6bea-4984-84fc-0af985bc95ea)
![image](https://github.com/user-attachments/assets/0226e4dc-f8aa-4396-82c0-40422527d12b)
![image](https://github.com/user-attachments/assets/ac0a3b29-cae9-464a-a27f-ae1d1e9ce0ef)
![image](https://github.com/user-attachments/assets/ca28e980-4046-451c-b10c-4505ce36e63f)
![image](https://github.com/user-attachments/assets/9f761c18-c611-4b8b-8e0a-184f7caf37d4)

## Remaining problems

- z thickness in the control pane is not updated
- we see the landmarks of the other somas even if they are not in the region of interest
- find out what z thickness actually does
- find out what voxel size does
![image](https://github.com/user-attachments/assets/4c5f638e-ec79-4b5e-8b98-4eee4f5d4137)

